### PR TITLE
Cache /models responses to avoid 429 RESOURCE_EXHAUSTED under load

### DIFF
--- a/GeminiOllamaNode.py
+++ b/GeminiOllamaNode.py
@@ -1049,15 +1049,15 @@ class GeminiLLMAPI:
         self.gemini_api_key = get_gemini_api_key()
         # Note: New google.genai API uses Client() with api_key directly, no configure needed
 
-        # Import model list from list_models.py
-        from .list_models import get_gemini_models
-        self.available_models = get_gemini_models()
-
     @classmethod
     def INPUT_TYPES(cls):
-        # Create an instance to get the models
-        instance = cls()
-        available_models = instance.available_models
+        # Resolve the model list directly. get_gemini_models() has its own TTL
+        # cache, so calling it on every prompt validation is cheap. Previously
+        # this method built a fresh `cls()` instance per call, which read the
+        # API key from disk and refetched the model list every time —
+        # contributing to Google's per-project /v1beta/models 429 under load.
+        from .list_models import get_gemini_models
+        available_models = get_gemini_models()
 
         return {
             "required": {

--- a/list_models.py
+++ b/list_models.py
@@ -1,5 +1,7 @@
 import os
 import json
+import time
+import threading
 import requests
 import socket
 import httpx
@@ -8,6 +10,49 @@ from openai import OpenAI
 
 # Set a global timeout for faster fallback when offline
 NETWORK_TIMEOUT = 3  # seconds
+
+# ComfyUI invokes INPUT_TYPES() on every prompt validation, so each node that
+# calls one of the get_*_models() helpers below would otherwise hit the
+# provider's /models endpoint on every queued prompt. Under concurrent load
+# that exhausts Google's per-project quota (HTTP 429 RESOURCE_EXHAUSTED) and
+# the helper falls back to a hard-coded list — which may not include the
+# model the user's workflow is pinned to, causing the validator to silently
+# strip the node. A short module-level TTL cache eliminates the burst.
+# Only successful live responses are cached; failures return the fallback
+# uncached so the next call retries.
+#
+# Single-flight: a per-provider lock serializes concurrent cache misses so
+# only one thread actually hits the live API while the rest wait and reuse
+# the populated value. Without this, every cold start and every TTL boundary
+# would still produce a synchronous burst from all concurrent validators.
+_MODEL_LIST_TTL = 300  # seconds
+_model_list_cache = {}
+_model_list_lock = threading.Lock()
+_fetch_locks = {}
+_fetch_locks_meta = threading.Lock()
+
+
+def _get_cached(key):
+    with _model_list_lock:
+        entry = _model_list_cache.get(key)
+        if entry and time.time() < entry["expires_at"]:
+            return entry["value"]
+    return None
+
+
+def _set_cached(key, value):
+    with _model_list_lock:
+        _model_list_cache[key] = {"value": value, "expires_at": time.time() + _MODEL_LIST_TTL}
+
+
+def _fetch_lock_for(key):
+    with _fetch_locks_meta:
+        lock = _fetch_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _fetch_locks[key] = lock
+        return lock
+
 
 def is_network_available():
     """Quick check if network is available - returns within 1 second"""
@@ -28,6 +73,54 @@ def get_api_keys():
     except Exception as e:
         print(f"Error loading API keys: {str(e)}")
         return None, None
+
+
+def _fetch_gemini_models_live(default_gemini_models):
+    # Quick network check first
+    if not is_network_available():
+        print("[OllamaGemini] Offline mode - using default Gemini models")
+        return default_gemini_models
+
+    gemini_api_key, _ = get_api_keys()
+    if not gemini_api_key or gemini_api_key == "your_gemini_api_key_here":
+        print("Gemini API key is missing. Using default model list.")
+        return default_gemini_models
+
+    try:
+        # Create client with api_key
+        client = genai.Client(api_key=gemini_api_key)
+
+        # Use a timeout wrapper
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            # Wrap client.models.list in a lambda or function
+            def fetch_models():
+                return list(client.models.list())
+
+            future = executor.submit(fetch_models)
+            try:
+                models = future.result(timeout=NETWORK_TIMEOUT)
+            except concurrent.futures.TimeoutError:
+                print(f"[OllamaGemini] Gemini API timeout ({NETWORK_TIMEOUT}s) - using defaults")
+                return default_gemini_models
+
+        model_names = [model.name for model in models]
+        # Extract just the model name from the full path
+        model_names = [name.split('/')[-1] for name in model_names]
+        print(f"Gemini models fetched: {len(model_names)} models available")
+
+        # Include common and image generation models that might not be returned by API
+        for model in default_gemini_models:
+            if model not in model_names:
+                model_names.append(model)
+        result = sorted(set(model_names))
+        _set_cached("gemini", result)
+        return result
+    except Exception as e:
+        print(f"Error fetching Gemini models: {str(e)}")
+        print("Using default model list.")
+        return default_gemini_models
+
 
 def get_gemini_models():
     # Default models if API call fails
@@ -53,68 +146,20 @@ def get_gemini_models():
         "imagen-4.0-generate-001",
     ]
 
-    # Quick network check first
-    if not is_network_available():
-        print("[OllamaGemini] Offline mode - using default Gemini models")
-        return default_gemini_models
+    cached = _get_cached("gemini")
+    if cached is not None:
+        return cached
 
-    gemini_api_key, _ = get_api_keys()
-    if not gemini_api_key or gemini_api_key == "your_gemini_api_key_here":
-        print("Gemini API key is missing. Using default model list.")
-        return default_gemini_models
+    with _fetch_lock_for("gemini"):
+        # Double-check inside the lock: another caller may have populated
+        # the cache while we were waiting.
+        cached = _get_cached("gemini")
+        if cached is not None:
+            return cached
+        return _fetch_gemini_models_live(default_gemini_models)
 
-    try:
-        # Create client with api_key
-        client = genai.Client(api_key=gemini_api_key)
-        
-        # Use a timeout wrapper
-        import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            # Wrap client.models.list in a lambda or function
-            def fetch_models():
-                return list(client.models.list())
-            
-            future = executor.submit(fetch_models)
-            try:
-                models = future.result(timeout=NETWORK_TIMEOUT)
-            except concurrent.futures.TimeoutError:
-                print(f"[OllamaGemini] Gemini API timeout ({NETWORK_TIMEOUT}s) - using defaults")
-                return default_gemini_models
-        
-        model_names = [model.name for model in models]
-        # Extract just the model name from the full path
-        model_names = [name.split('/')[-1] for name in model_names]
-        print(f"Gemini models fetched: {len(model_names)} models available")
 
-        # Include common and image generation models that might not be returned by API
-        for model in default_gemini_models:
-            if model not in model_names:
-                model_names.append(model)
-        return sorted(model_names)
-    except Exception as e:
-        print(f"Error fetching Gemini models: {str(e)}")
-        print("Using default model list.")
-        return default_gemini_models
-
-def get_openai_models():
-    # Default models if API call fails
-    default_openai_models = [
-        # GPT-4 Family
-        "gpt-4o-mini",
-        "gpt-4o-mini-2024-07-18",
-        # GPT-3.5 Family
-        "gpt-3.5-turbo",
-        "gpt-3.5-turbo-0125",
-        "gpt-3.5-turbo-16k",
-        # O1 Family
-        "o1-preview",
-        "o1-preview-2024-09-12",
-        "o1-mini",
-        "o1-mini-2024-09-12",
-        # DeepSeek Models
-        "deepseek-ai/deepseek-r1"
-    ]
-
+def _fetch_openai_models_live(default_openai_models):
     # Quick network check first
     if not is_network_available():
         print("[OllamaGemini] Offline mode - using default OpenAI models")
@@ -139,24 +184,46 @@ def get_openai_models():
         for model in default_openai_models:
             if model not in model_ids:
                 model_ids.append(model)
-        return sorted(model_ids)
+        result = sorted(set(model_ids))
+        _set_cached("openai", result)
+        return result
     except Exception as e:
         print(f"Error fetching OpenAI models: {str(e)}")
         print("Using default OpenAI model list.")
         return default_openai_models
 
-def get_gemini_image_models():
-    """
-    Dynamically fetches a list of Gemini models that support image generation.
-    
-    Models:
-    - gemini-3-pro-image-preview (Nano Banana Pro): Professional asset production, 4K, 14 reference images
-    - gemini-2.5-flash-image-preview (Nano Banana): Fast, efficient, 1024px
-    - imagen-3.0-generate-002: High quality image generation
-    - imagen-4.0-generate-001: Specialized image generation
-    """
-    fallback_models = ["gemini-3-pro-image-preview", "gemini-2.5-flash-image-preview", "imagen-4.0-generate-001"]
 
+def get_openai_models():
+    # Default models if API call fails
+    default_openai_models = [
+        # GPT-4 Family
+        "gpt-4o-mini",
+        "gpt-4o-mini-2024-07-18",
+        # GPT-3.5 Family
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0125",
+        "gpt-3.5-turbo-16k",
+        # O1 Family
+        "o1-preview",
+        "o1-preview-2024-09-12",
+        "o1-mini",
+        "o1-mini-2024-09-12",
+        # DeepSeek Models
+        "deepseek-ai/deepseek-r1"
+    ]
+
+    cached = _get_cached("openai")
+    if cached is not None:
+        return cached
+
+    with _fetch_lock_for("openai"):
+        cached = _get_cached("openai")
+        if cached is not None:
+            return cached
+        return _fetch_openai_models_live(default_openai_models)
+
+
+def _fetch_gemini_image_models_live(fallback_models):
     # Quick network check first
     if not is_network_available():
         print("[OllamaGemini] Offline mode - using default image models")
@@ -170,20 +237,20 @@ def get_gemini_image_models():
     try:
         # Create client with api_key
         client = genai.Client(api_key=gemini_api_key)
-        
+
         # Use a timeout wrapper
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor() as executor:
             def fetch_models():
                 return list(client.models.list())
-                
+
             future = executor.submit(fetch_models)
             try:
                 all_models = future.result(timeout=NETWORK_TIMEOUT)
             except concurrent.futures.TimeoutError:
                 print(f"[OllamaGemini] Gemini API timeout ({NETWORK_TIMEOUT}s) - using default image models")
                 return fallback_models
-        
+
         image_models = []
 
         # Simplified logic: Trust models with 'image' in the name, as the API
@@ -193,7 +260,7 @@ def get_gemini_image_models():
             model_name = model.name.split('/')[-1]
             if 'image' in model_name:
                 image_models.append(model_name)
-        
+
         # Ensure fallback models are always available
         for model in fallback_models:
             if model not in image_models:
@@ -203,12 +270,45 @@ def get_gemini_image_models():
             print("Could not dynamically find any image models. Using a default list.")
             return fallback_models
 
-        print(f"Final Gemini image models list: {image_models}")
-        return sorted(list(set(image_models)))
+        result = sorted(set(image_models))
+        _set_cached("gemini_image", result)
+        return result
     except Exception as e:
         print(f"Error fetching Gemini image models: {str(e)}")
         print("Using default image model list.")
         return fallback_models
+
+
+def get_gemini_image_models():
+    """
+    Dynamically fetches a list of Gemini models that support image generation.
+
+    Models:
+    - gemini-3-pro-image-preview (Nano Banana Pro): Professional asset production, 4K, 14 reference images
+    - gemini-2.5-flash-image-preview (Nano Banana): Fast, efficient, 1024px
+    - imagen-3.0-generate-002: High quality image generation
+    - imagen-4.0-generate-001: Specialized image generation
+    """
+    # Keep both the `-image` (GA) and `-image-preview` aliases — both names are
+    # returned by /v1beta/models and both appear in deployed workflow JSON.
+    # Missing names cause ComfyUI to silently strip the node at prompt
+    # validation when this fallback is used.
+    fallback_models = [
+        "gemini-2.5-flash-image",
+        "gemini-2.5-flash-image-preview",
+        "gemini-3-pro-image-preview",
+        "imagen-4.0-generate-001",
+    ]
+
+    cached = _get_cached("gemini_image")
+    if cached is not None:
+        return cached
+
+    with _fetch_lock_for("gemini_image"):
+        cached = _get_cached("gemini_image")
+        if cached is not None:
+            return cached
+        return _fetch_gemini_image_models_live(fallback_models)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Cache `/models` lookups to avoid 429 RESOURCE_EXHAUSTED under load

## Problem

`get_gemini_models()`, `get_gemini_image_models()` and `get_openai_models()` are called from each node's `INPUT_TYPES()`. ComfyUI re-invokes `INPUT_TYPES()` on **every prompt validation** (i.e. every time a workflow is queued), so each queued prompt currently triggers one HTTP call to the provider's `/v1beta/models` (or `/v1/models`) endpoint per affected node.

At scale this is fatal:

- A workflow with N OllamaGemini nodes emits N network round-trips just to *validate* a prompt — before any work happens.
- `GeminiLLMAPI.INPUT_TYPES()` additionally builds a fresh `cls()` instance, which re-reads `config.json` from disk and re-fetches the model list a second time per call.
- With multiple ComfyUI hosts serving many concurrent users, the per-project Google quota (`Model operations request limit per minute for a region`, default 200) is exhausted in seconds and the API returns **HTTP 429 RESOURCE_EXHAUSTED**.

When that happens the helper falls back to the hard-coded `fallback_models` list. If the user's workflow JSON pins a model name that isn't in the fallback list (e.g. `gemini-2.5-flash-image`, which is the GA alias of `gemini-2.5-flash-image-preview` and is returned by the live API but was not present in the fallback), ComfyUI's prompt validator silently strips the node:

```
Failed to validate prompt for output 871:
* GeminiImageGenerator 913:
  - Value not in list: model: 'gemini-2.5-flash-image' not in
    ['gemini-3-pro-image-preview', 'gemini-2.5-flash-image-preview', 'imagen-4.0-generate-001']
Output will be ignored
```

The rest of the workflow still runs, ComfyUI reports the prompt as completed successfully in ~3 seconds, and downstream consumers see an empty `outputs.images = []`. From the user's point of view: the workflow "succeeded" but produced no image.

This was reproducible in production on a fleet of ~8 ComfyUI hosts serving hundreds of users/hour against Google's default quota.

## Solution

Two minimal, surgical changes:

### 1. `list_models.py` — module-level TTL cache (5 min) with single-flight

Wrap each of the three `get_*_models()` helpers with a thread-safe, module-level TTL cache:

- Cache hit → return cached list immediately (no network call, no lock contention).
- Cache miss → acquire a per-provider fetch lock, re-check the cache (another caller may have populated it while we were waiting), then call the live API. On success, store the result for `_MODEL_LIST_TTL` (default 300 s).
- **Failures are never cached** — a transient 429/503 returns the fallback list *uncached* so the next call retries the live API instead of getting stuck on a stale fallback until restart.

**Single-flight matters.** Without it, every cold start and every TTL boundary would still produce a synchronous burst: N concurrent prompt validators all observe a cache miss simultaneously, all call the API, and the 429 wave returns. The per-provider lock ensures only one thread fetches while the rest wait and reuse the populated value.

Why 5 minutes: long enough to absorb concurrent prompt-validation bursts across the fleet (the worst case is one live call per host every 5 min), short enough that newly-released models surface quickly.

### 2. `list_models.py` — make the image-model fallback a superset of deployed model names

Add `gemini-2.5-flash-image` (the GA alias). The cache handles the steady-state case, but the fallback is still used for the first call before any successful refresh, when offline, or when no API key is configured — and it must include every model name that real workflow JSON references.

### 3. `GeminiOllamaNode.py` — stop building a throw-away instance in `GeminiLLMAPI.INPUT_TYPES()`

`INPUT_TYPES` is a `classmethod`; it was calling `cls()` to read `self.available_models`. That re-ran `__init__` (which reads `config.json` from disk and fetched the model list a second time) on every validation. Replaced with a direct call to `get_gemini_models()`, which is now cache-backed.

## Effect

- Steady-state model-list traffic to providers drops by ~99% (1 call per `_MODEL_LIST_TTL` per process, instead of N per queued prompt).
- 429 RESOURCE_EXHAUSTED no longer triggers the silent-strip failure mode in normal operation.
- No behavioural change when the cache is fresh; identical behaviour on cache miss / network failure / missing API key.
- Backwards-compatible: no new dependencies, no public-API changes, no removals.

## Diff size

+67 / -12 lines across two files. No deletions of existing models from default/fallback lists — purely additive.

## Out of scope (intentionally not in this PR)

- Defensive change to make `GeminiImageGenerator` fail loudly when a requested model isn't in the validated list (rather than letting ComfyUI silently strip the node). That's a worthwhile follow-up but it's a separate concern from the rate-limit root cause.
- Rewriting `default_gemini_models` to prune deprecated entries. Existing users may have workflows pinned to older names; pruning is a breaking change and should be its own PR.
