### PR TITLE
Refresh default + fallback model lists against deprecation schedule

### DIFF
--- a/list_models.py
+++ b/list_models.py
@@ -30,27 +30,33 @@ def get_api_keys():
         return None, None
 
 def get_gemini_models():
-    # Default models if API call fails
+    # Default models if API call fails. Sourced from
+    # https://ai.google.dev/gemini-api/docs/deprecations — last reviewed
+    # 2026-05-26. Entries that have already passed their shutdown date
+    # (gemini-1.5-*, gemini-3-pro-preview, gemini-2.5-pro-exp-03-25,
+    # gemini-2.5-flash-image-preview, gemini-2.0-flash-exp-image-generation,
+    # imagen-3.0-generate-002) have been removed. When updating this list,
+    # cross-check the deprecation page and annotate each entry with its
+    # earliest shutdown date so the next maintainer knows what to refresh.
     default_gemini_models = [
-        # Gemini 3.x Models (newest)
-        "gemini-3-pro-preview",
-        "gemini-3-pro-image-preview",
-        "gemini-3-flash-preview",
-        # Gemini 2.5 Models
-        "gemini-2.5-pro-exp-03-25",
+        # Gemini 3.x
+        "gemini-3.1-pro-preview",          # no shutdown date announced
+        "gemini-3-pro-image-preview",      # no shutdown date announced
+        "gemini-3.1-flash-image-preview",  # no shutdown date announced
+        "gemini-3.5-flash",                # GA, no shutdown date announced
+        "gemini-3-flash-preview",          # replacement: gemini-3.5-flash
+        # Gemini 2.5 GA (shutdown 2026-10-16)
+        "gemini-2.5-pro",
         "gemini-2.5-flash",
-        "gemini-2.5-flash-image-preview",
-        # Gemini 2.0 Models
+        "gemini-2.5-flash-lite",
+        "gemini-2.5-flash-image",          # shutdown 2026-10-02
+        # Gemini 2.0 (shutdown 2026-06-01 — replacement: gemini-2.5-flash / -lite)
         "gemini-2.0-flash",
         "gemini-2.0-flash-lite",
-        "gemini-2.0-flash-exp-image-generation",
-        # Gemini 1.5 Models
-        "gemini-1.5-pro",
-        "gemini-1.5-flash",
-        "gemini-1.5-flash-8b",
-        # Image Generation Models
-        "imagen-3.0-generate-002",
+        # Imagen 4 (shutdown 2026-06-24 — replacement: gemini-3-pro-image-preview or gemini-2.5-flash-image)
         "imagen-4.0-generate-001",
+        "imagen-4.0-ultra-generate-001",
+        "imagen-4.0-fast-generate-001",
     ]
 
     # Quick network check first
@@ -148,14 +154,21 @@ def get_openai_models():
 def get_gemini_image_models():
     """
     Dynamically fetches a list of Gemini models that support image generation.
-    
-    Models:
-    - gemini-3-pro-image-preview (Nano Banana Pro): Professional asset production, 4K, 14 reference images
-    - gemini-2.5-flash-image-preview (Nano Banana): Fast, efficient, 1024px
-    - imagen-3.0-generate-002: High quality image generation
-    - imagen-4.0-generate-001: Specialized image generation
+
+    Models (verified against the deprecation schedule on 2026-05-26):
+    - gemini-2.5-flash-image (Nano Banana, GA): shutdown 2026-10-02
+    - gemini-3-pro-image-preview (Nano Banana Pro, Preview): no shutdown date
+    - gemini-3.1-flash-image-preview (Nano Banana 2, Preview): no shutdown date
+    - imagen-4.0-generate-001: shutdown 2026-06-24
     """
-    fallback_models = ["gemini-3-pro-image-preview", "gemini-2.5-flash-image-preview", "imagen-4.0-generate-001"]
+    # gemini-2.5-flash-image-preview was shut down 2026-01-15; the GA name is
+    # gemini-2.5-flash-image. imagen-3.0-generate-002 was shut down 2025-11-10.
+    fallback_models = [
+        "gemini-2.5-flash-image",          # shutdown 2026-10-02
+        "gemini-3-pro-image-preview",      # no shutdown date announced
+        "gemini-3.1-flash-image-preview",  # no shutdown date announced
+        "imagen-4.0-generate-001",         # shutdown 2026-06-24
+    ]
 
     # Quick network check first
     if not is_network_available():


### PR DESCRIPTION
# Refresh default + fallback model lists against Google's deprecation schedule

Cross-checked `default_gemini_models` (in `get_gemini_models()`) and `fallback_models` (in `get_gemini_image_models()`) against [Google's deprecation page](https://ai.google.dev/gemini-api/docs/deprecations) as of 2026-05-26.

## Why this matters

These lists serve three paths that bypass the live `/v1beta/models` lookup:

1. **Cold start before any successful cache fill** (especially under quota pressure — see #58)
2. **No network** (`is_network_available()` false)
3. **No API key configured**

In all three paths, ComfyUI uses these lists to populate the model dropdown. If a list contains a name that Google has already retired, a request to that model now 404s at Google's side rather than failing cleanly in ComfyUI. If a list omits a name that newer workflows reference, ComfyUI's prompt validator silently strips the node ("Output will be ignored") and the workflow appears to succeed while producing no image.

So the list should be both:
- **a true subset of currently-serving models** (no dead names)
- **a superset of every model name that real workflow JSON might pin** (cover both `-image` GA aliases and `-image-preview` historical names where both still serve)

## What changed

### `default_gemini_models` — `get_gemini_models()`

**Removed (already past their shutdown date as of 2026-05-26):**

| Removed entry | Shutdown date | Recommended replacement |
|---|---|---|
| `gemini-3-pro-preview` | 2026-03-09 | `gemini-3.1-pro-preview` |
| `gemini-2.5-pro-exp-03-25` | 2025-12-02 | `gemini-3.1-pro-preview` |
| `gemini-2.5-flash-image-preview` | 2026-01-15 | `gemini-2.5-flash-image` |
| `gemini-2.0-flash-exp-image-generation` | 2025-11-14 | `gemini-2.5-flash-image` |
| `gemini-1.5-pro` / `-flash` / `-flash-8b` | long shut down | n/a |
| `imagen-3.0-generate-002` | 2025-11-10 | `imagen-4.0-generate-001` |

**Kept (with `# shutdown YYYY-MM-DD` annotation so the next refresh is obvious):**
- `gemini-2.0-flash`, `gemini-2.0-flash-lite` — shutdown 2026-06-01 (imminent, but the replacements `gemini-2.5-flash` / `-lite` are listed alongside)
- `imagen-4.0-generate-001` and friends — shutdown 2026-06-24

**Added:**
- `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.5-flash` (replacements for the dropped previews)
- `gemini-2.5-pro`, `gemini-2.5-flash-lite`, `gemini-2.5-flash-image` (GA names)
- `imagen-4.0-ultra-generate-001`, `imagen-4.0-fast-generate-001` (returned by `/v1beta/models`)

### `fallback_models` — `get_gemini_image_models()`

- Dropped `gemini-2.5-flash-image-preview` (shut down 2026-01-15) → the GA name `gemini-2.5-flash-image` is now the canonical entry.
- Added `gemini-3.1-flash-image-preview` (Nano Banana 2).
- Annotated each surviving entry with its shutdown date and updated the docstring to match.

## Diff size

+36 / -23 lines, one file. No new dependencies, no API changes, no behavioural changes to the cache/fetch logic.

## Relation to other PRs

Independent of #58 (the 5-minute TTL cache + single-flight fix). Both can be merged in either order. This PR addresses **what** the fallback contains; #58 addresses **how often** it's used.

## Maintenance note

The added comments name the deprecation page and the review date (`2026-05-26`). Suggestion: revisit this list every quarter, or whenever someone hits a "model not found" with a name from the dropdown.
